### PR TITLE
klte: libinit: Align radio power save prop to stock

### DIFF
--- a/init/init_klte.cpp
+++ b/init/init_klte.cpp
@@ -85,6 +85,7 @@ void vendor_load_properties()
     } else if (bootloader.find("G900T") == 0) {
         /* kltetmo */
         property_override("ro.build.description", "kltetmo-user 6.0.1 MMB29M G900TUVU1GQC2 release-keys");
+        property_set("persist.radio.add_power_save", "0");
         set_ro_product_prop("device", "kltetmo");
         set_ro_product_prop("fingerprint", "samsung/kltetmo/kltetmo:6.0.1/MMB29M/G900TUVU1GQC2:user/release-keys");
         set_ro_product_prop("model", "SM-G900T");
@@ -102,6 +103,7 @@ void vendor_load_properties()
     } else if (bootloader.find("G900W8") == 0) {
         /* kltecan */
         property_override("ro.build.description", "kltevl-user 6.0.1 MMB29M G900W8VLU1DQB2 release-keys");
+        property_set("persist.radio.add_power_save", "0");
         set_ro_product_prop("device", "kltecan");
         set_ro_product_prop("fingerprint", "samsung/kltevl/kltecan:6.0.1/MMB29M/G900W8VLU1DQB2:user/release-keys");
         set_ro_product_prop("model", "SM-G900W8");


### PR DESCRIPTION
* There are reports that *some* G900T devices get into a state where
  they report that only emergency calls are possible after the screen
  turns off for some period. This does not affect all G900T devices,
  but on affected ones, removing the persist.radio.add_power_save
  property from build.prop seems to fix it.
* As it turns out, Samsung doesn't set this prop on G900A, G900T, and
  G900W8, but does on all the rest of the variants. Samsung must have
  a reason for this, so we'll follow along.
* Given that the vast majority do set this prop, we'll leave it as
  set to 1 in klte-common, but re-set it to 0 for these two supported
  variants in libinit.

Change-Id: I4428aa0662f77e2b25b9bd38bcba30ce59c13ab4